### PR TITLE
Do not build images from JDK8 base image for arm64

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -27,6 +27,10 @@ inputs:
     type: string
     required: false
     default: linux/amd64,linux/arm64
+  SUB_DIRECTORY:
+    description: Sub directory where dockerfile is located
+    type: string
+    required: false
 
 runs:
   using: composite
@@ -62,8 +66,20 @@ runs:
 
     - name: Build and push
       uses: docker/build-push-action@v2
+      if:  ${{ inputs.SUB_DIRECTORY == '' }}
       with:
-        context: "{{ defaultContext }}"
+        context: '{{ defaultContext }}'
+        platforms: ${{ inputs.platforms }}
+        push: ${{ github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v')) }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: ${{ inputs.TAG_NAME }}=${{ inputs.BASE_TAG }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      if:  ${{ inputs.SUB_DIRECTORY != '' }}
+      with:
+        context: '{{ defaultContext }}:${{inputs.SUB_DIRECTORY}}'
         platforms: ${{ inputs.platforms }}
         push: ${{ github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v')) }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -8,10 +8,20 @@ on:
         required: false
         default: 4.13.2-1-jdk11-5a9ba13-a7f7fa0
         description: NVM_TAG to build
+      NVM_TAG_JDK8:
+        type: string
+        required: false
+        default: 4.13.2-1-jdk8-5a9ba13-a7f7fa0
+        description: NVM_TAG to build
       CORE_TAG:
         type: string
         required: false
         default: 4.13.2-1-jdk11-5a9ba13
+        description: CORE_TAG to build
+      CORE_TAG_JDK8:
+        type: string
+        required: false
+        default: 4.13.2-1-jdk8-5a9ba13
         description: CORE_TAG to build
       IMAGE_NAME:
         description: Name of image to publish to dockerhub, e.g. 'dwolla/my-image'
@@ -26,6 +36,15 @@ on:
         type: string
         required: false
         default: linux/amd64,linux/arm64
+      SUB_DIRECTORY:
+        description: Sub directory where dockerfile is located
+        type: string
+        required: false
+      ACTION_BRANCH:
+        description: Branch with build action to call (defaults to main)
+        type: string
+        required: false
+        default: main
     secrets: 
       DOCKERHUB_USERNAME:
         required: true
@@ -36,12 +55,18 @@ env:
   TAG: ${{ inputs[inputs.TAG_NAME] }}
 
 jobs:
+
   build:
     if: ${{ inputs.TAG_NAME == 'NVM_TAG' || inputs.TAG_NAME == 'CORE_TAG' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: Dwolla/jenkins-agents-workflow
+          ref: ${{ inputs.ACTION_BRANCH }}
       - name: Build and Push Docker Image
-        uses: Dwolla/jenkins-agents-workflow/.github/actions/build@main
+        uses: ./.github/actions/build
         with:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -49,39 +74,88 @@ jobs:
           TAG_NAME: ${{ inputs.TAG_NAME }}
           IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
           PLATFORMS: ${{ inputs.PLATFORMS }}
+          SUB_DIRECTORY: ${{ inputs.SUB_DIRECTORY }}
 
-  build-core-matrix:
-    strategy:
-      matrix:
-        TAG:
-          - 4.13.2-1-jdk11-5a9ba13
-          - 4.13.2-1-jdk8-5a9ba13
+
+  build-core-jdk8:
     if: ${{ inputs.TAG_NAME == 'CORE_TAG_JDK8_JDK11' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: Dwolla/jenkins-agents-workflow
+          ref: ${{ inputs.ACTION_BRANCH }}
       - name: Build and Push Docker Image
-        uses: Dwolla/jenkins-agents-workflow/.github/actions/build@main
+        uses: ./.github/actions/build
         with:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          BASE_TAG: ${{ matrix.TAG }}
+          BASE_TAG: ${{ inputs.CORE_TAG_JDK8 }}
           TAG_NAME: "CORE_TAG"
           IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
+          PLATFORMS: linux/amd64
+          SUB_DIRECTORY: ${{ inputs.SUB_DIRECTORY }}
 
-  build-nvm-matrix:
-    strategy:
-      matrix:
-        TAG:
-          - 4.13.2-1-jdk11-5a9ba13-a7f7fa0
-          - 4.13.2-1-jdk8-5a9ba13-a7f7fa0
+
+  build-core-jdk11:
+    if: ${{ inputs.TAG_NAME == 'CORE_TAG_JDK8_JDK11' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: Dwolla/jenkins-agents-workflow
+          ref: ${{ inputs.ACTION_BRANCH }}
+      - name: Build and Push Docker Image
+        uses: ./.github/actions/build
+        with:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          BASE_TAG: ${{ inputs.CORE_TAG }}
+          TAG_NAME: "CORE_TAG"
+          IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
+          PLATFORMS: ${{ inputs.PLATFORMS }}
+          SUB_DIRECTORY: ${{ inputs.SUB_DIRECTORY }}
+
+
+  build-nvm-jdk8:
     if: ${{ inputs.TAG_NAME == 'NVM_TAG_JDK8_JDK11' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: Dwolla/jenkins-agents-workflow
+          ref: ${{ inputs.ACTION_BRANCH }}
       - name: Build and Push Docker Image
-        uses: Dwolla/jenkins-agents-workflow/.github/actions/build@main
+        uses: ./.github/actions/build
         with:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          BASE_TAG: ${{ matrix.TAG }}
+          BASE_TAG: ${{ inputs.NVM_TAG_JDK8 }}
           TAG_NAME: "NVM_TAG"
           IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
+          PLATFORMS: linux/amd64
+          SUB_DIRECTORY: ${{ inputs.SUB_DIRECTORY }}
+
+  build-nvm-jdk11:
+    if: ${{ inputs.TAG_NAME == 'NVM_TAG_JDK8_JDK11' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: Dwolla/jenkins-agents-workflow
+          ref: ${{ inputs.ACTION_BRANCH }}
+      - name: Build and Push Docker Image
+        uses: ./.github/actions/build
+        with:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          BASE_TAG: ${{ inputs.NVM_TAG }}
+          TAG_NAME: "NVM_TAG"
+          IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
+          PLATFORMS: ${{ inputs.PLATFORMS }}
+          SUB_DIRECTORY: ${{ inputs.SUB_DIRECTORY }}
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,72 @@
+name: Test Jenkins Agent Workflow
+
+on:
+  push:
+
+jobs:
+  test-nvm-jdk8-jdk11:
+    uses: ./.github/workflows/build-docker-image.yml
+    with:
+      IMAGE_NAME: test-nvm-jdk8-jdk11
+      TAG_NAME: NVM_TAG_JDK8_JDK11
+      SUB_DIRECTORY: test/NVM_TAG
+      ACTION_BRANCH: ${{ github.ref_name }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  test-nvm:
+    uses: ./.github/workflows/build-docker-image.yml
+    with:
+      IMAGE_NAME: test-nvm
+      TAG_NAME: NVM_TAG
+      SUB_DIRECTORY: test/NVM_TAG
+      ACTION_BRANCH: ${{ github.ref_name }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  test-core-jdk8-jdk11:
+    needs: [test-nvm-jdk8-jdk11, test-nvm]
+    uses: ./.github/workflows/build-docker-image.yml
+    with:
+      IMAGE_NAME: test-core-jdk8-jdk11
+      TAG_NAME: CORE_TAG_JDK8_JDK11
+      SUB_DIRECTORY: test/CORE_TAG
+      ACTION_BRANCH: ${{ github.ref_name }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  test-core:
+    needs: [test-nvm-jdk8-jdk11, test-nvm]
+    uses: ./.github/workflows/build-docker-image.yml
+    with:
+      IMAGE_NAME: test-core
+      TAG_NAME: CORE_TAG
+      SUB_DIRECTORY: test/CORE_TAG
+      ACTION_BRANCH: ${{ github.ref_name }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  test-action:
+    needs: [test-core-jdk8-jdk11, test-core]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/build
+        with:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          BASE_TAG: 8u322-b06-jre
+          TAG_NAME: TEMURIN_TAG
+          IMAGE_NAME: test-action
+          SUB_DIRECTORY: test/build-action
+
+  build-complete:
+    needs: [test-nvm-jdk8-jdk11, test-nvm, test-core-jdk8-jdk11, test-core, test-action]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The build completed successfully"

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Reusable workflow for building and pushing jenkins agents docker images.
 
 SUPPORTED TAG NAMES:
 * NVM_TAG (defaults to core JDK11)
-* NVM_TAG_JDK8_JDK11 (builds matrix for core JDK8 and JDK11)
+* NVM_TAG_JDK8_JDK11 (builds amd64 for JDK8 and arm64/amd64 for JDK11)
 * CORE_TAG (defaults to JDK11)
-* CORE_TAG_JDK8_JDK11 (builds matrix for JDK8 and JDK11 defaults)
+* CORE_TAG_JDK8_JDK11 (builds amd64 for JDK8 and arm64/amd64 for JDK11)
 
 ## Common Usage:
 
@@ -97,4 +97,26 @@ jobs:
 ## Development & Contribution
 
 To test changes, push to a new branch on jenkins-agents-workflows and modify caller-workflow to point to new branch.
-* _Note: To test changes to the [composite action](./github/actions/build/action.yml) in this repository, also modify the action call in [jenkins-agent-workflow build.yml](./github/workflows/build.yml) on your branch to point to your workflow._
+Also, tests run automatically for the currently supported tag names.
+
+## Utilizing `yq` to build caller workflow images locally
+
+With [yq](https://kislyuk.github.io/yq/) installed to build a caller image locally run the following command to retrieve the tag name:
+
+```
+curl --silent https://raw.githubusercontent.com/Dwolla/jenkins-agents-workflow/main/.github/workflows/build-docker-image.yml | yq -r .on.workflow_call.inputs.<my-core-tag>.default
+```
+
+Where `my-core-tag`&nbsp; is one of the following:
+* `NVM_TAG`
+* `NVM_TAG_JDK8`
+* `CORE_TAG`
+* `CORE_TAG_JDK8`.
+
+Alternatively, without [yq](https://kislyuk.github.io/yq/) installed, refer to the default value(s) defined in [jenkins-agents-workflow](https://github.com/Dwolla/jenkins-agents-workflow/blob/main/.github/workflows/build-docker-image.yml):
+
+Finally, run the following command:
+
+`make <my-core-tag-arg-name>=<default-value-from-jenkins-agents-workflow> all`
+
+Where `my-core-tag-arg-name` is defined in the Dockerfile and/or Makefile of the caller workflow.

--- a/test/CORE_TAG/Dockerfile
+++ b/test/CORE_TAG/Dockerfile
@@ -1,0 +1,8 @@
+ARG CORE_TAG
+
+FROM dwolla/jenkins-agent-core:$CORE_TAG
+
+USER root
+RUN chown -R jenkins ${JENKINS_HOME}
+
+USER jenkins

--- a/test/NVM_TAG/Dockerfile
+++ b/test/NVM_TAG/Dockerfile
@@ -1,0 +1,8 @@
+ARG NVM_TAG
+
+FROM dwolla/jenkins-agent-nvm:$NVM_TAG
+
+USER root
+RUN chown -R jenkins ${JENKINS_HOME}
+
+USER jenkins

--- a/test/build-action/Dockerfile
+++ b/test/build-action/Dockerfile
@@ -1,0 +1,5 @@
+ARG TEMURIN_TAG
+
+FROM eclipse-temurin:$TEMURIN_TAG
+
+RUN echo "dummy dockerfile, do nothing"


### PR DESCRIPTION
A jenkins agent caller workflow was able to successfully build calling this branch [here](https://github.com/Dwolla/jenkins-agent-docker-nvm-sbt/actions/runs/2964664907).

This PR also adds some tests for the different TAG_NAMES `jenkins-agents-workflow` currently supports.
