### PR TITLE
check for jdk8 on the fly, then specify amd64

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -69,7 +69,7 @@ runs:
       if:  ${{ inputs.SUB_DIRECTORY == '' }}
       with:
         context: '{{ defaultContext }}'
-        platforms: ${{ inputs.platforms }}
+        platforms: ${{ contains(inputs.BASE_TAG, 'jdk8') && 'linux/amd64' || inputs.PLATFORMS }}
         push: ${{ github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v')) }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
@@ -80,7 +80,7 @@ runs:
       if:  ${{ inputs.SUB_DIRECTORY != '' }}
       with:
         context: '{{ defaultContext }}:${{inputs.SUB_DIRECTORY}}'
-        platforms: ${{ inputs.platforms }}
+        platforms: ${{ contains(inputs.BASE_TAG, 'jdk8') && 'linux/amd64' || inputs.PLATFORMS }}
         push: ${{ github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v')) }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -8,20 +8,10 @@ on:
         required: false
         default: 4.13.2-1-jdk11-5a9ba13-a7f7fa0
         description: NVM_TAG to build
-      NVM_TAG_JDK8:
-        type: string
-        required: false
-        default: 4.13.2-1-jdk8-5a9ba13-a7f7fa0
-        description: NVM_TAG to build
       CORE_TAG:
         type: string
         required: false
         default: 4.13.2-1-jdk11-5a9ba13
-        description: CORE_TAG to build
-      CORE_TAG_JDK8:
-        type: string
-        required: false
-        default: 4.13.2-1-jdk8-5a9ba13
         description: CORE_TAG to build
       IMAGE_NAME:
         description: Name of image to publish to dockerhub, e.g. 'dwolla/my-image'
@@ -77,7 +67,12 @@ jobs:
           SUB_DIRECTORY: ${{ inputs.SUB_DIRECTORY }}
 
 
-  build-core-jdk8:
+  build-core-matrix:
+    strategy:
+      matrix:
+        TAG:
+          - 4.13.2-1-jdk11-5a9ba13
+          - 4.13.2-1-jdk8-5a9ba13
     if: ${{ inputs.TAG_NAME == 'CORE_TAG_JDK8_JDK11' }}
     runs-on: ubuntu-latest
     steps:
@@ -91,35 +86,19 @@ jobs:
         with:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          BASE_TAG: ${{ inputs.CORE_TAG_JDK8 }}
-          TAG_NAME: "CORE_TAG"
-          IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
-          PLATFORMS: linux/amd64
-          SUB_DIRECTORY: ${{ inputs.SUB_DIRECTORY }}
-
-
-  build-core-jdk11:
-    if: ${{ inputs.TAG_NAME == 'CORE_TAG_JDK8_JDK11' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: Dwolla/jenkins-agents-workflow
-          ref: ${{ inputs.ACTION_BRANCH }}
-      - name: Build and Push Docker Image
-        uses: ./.github/actions/build
-        with:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          BASE_TAG: ${{ inputs.CORE_TAG }}
+          BASE_TAG: ${{ matrix.TAG }}
           TAG_NAME: "CORE_TAG"
           IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
           PLATFORMS: ${{ inputs.PLATFORMS }}
           SUB_DIRECTORY: ${{ inputs.SUB_DIRECTORY }}
 
 
-  build-nvm-jdk8:
+  build-nvm-matrix:
+    strategy:
+      matrix:
+        TAG:
+          - 4.13.2-1-jdk11-5a9ba13-a7f7fa0
+          - 4.13.2-1-jdk8-5a9ba13-a7f7fa0
     if: ${{ inputs.TAG_NAME == 'NVM_TAG_JDK8_JDK11' }}
     runs-on: ubuntu-latest
     steps:
@@ -133,29 +112,8 @@ jobs:
         with:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          BASE_TAG: ${{ inputs.NVM_TAG_JDK8 }}
-          TAG_NAME: "NVM_TAG"
-          IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
-          PLATFORMS: linux/amd64
-          SUB_DIRECTORY: ${{ inputs.SUB_DIRECTORY }}
-
-  build-nvm-jdk11:
-    if: ${{ inputs.TAG_NAME == 'NVM_TAG_JDK8_JDK11' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: Dwolla/jenkins-agents-workflow
-          ref: ${{ inputs.ACTION_BRANCH }}
-      - name: Build and Push Docker Image
-        uses: ./.github/actions/build
-        with:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          BASE_TAG: ${{ inputs.NVM_TAG }}
+          BASE_TAG: ${{ matrix.TAG }}
           TAG_NAME: "NVM_TAG"
           IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
           PLATFORMS: ${{ inputs.PLATFORMS }}
           SUB_DIRECTORY: ${{ inputs.SUB_DIRECTORY }}
-

--- a/README.md
+++ b/README.md
@@ -98,25 +98,3 @@ jobs:
 
 To test changes, push to a new branch on jenkins-agents-workflows and modify caller-workflow to point to new branch.
 Also, tests run automatically for the currently supported tag names.
-
-## Utilizing `yq` to build caller workflow images locally
-
-With [yq](https://kislyuk.github.io/yq/) installed to build a caller image locally run the following command to retrieve the tag name:
-
-```
-curl --silent https://raw.githubusercontent.com/Dwolla/jenkins-agents-workflow/main/.github/workflows/build-docker-image.yml | yq -r .on.workflow_call.inputs.<my-core-tag>.default
-```
-
-Where `my-core-tag`&nbsp; is one of the following:
-* `NVM_TAG`
-* `NVM_TAG_JDK8`
-* `CORE_TAG`
-* `CORE_TAG_JDK8`.
-
-Alternatively, without [yq](https://kislyuk.github.io/yq/) installed, refer to the default value(s) defined in [jenkins-agents-workflow](https://github.com/Dwolla/jenkins-agents-workflow/blob/main/.github/workflows/build-docker-image.yml):
-
-Finally, run the following command:
-
-`make <my-core-tag-arg-name>=<default-value-from-jenkins-agents-workflow> all`
-
-Where `my-core-tag-arg-name` is defined in the Dockerfile and/or Makefile of the caller workflow.


### PR DESCRIPTION
Shoutout to @bpholt for pointing this out!

We can simply check if the base tag name includes the substring JDK8 and then specify `linux/amd64` from there.

As a result, we don't need to change how the NVM_TAG and CORE_TAG are defined in the workflow for JDK8 or update the READMEs of downstream workflows to accommodate that change.