### PR TITLE
Update dwolla/jenkins-agent-core to 4.13.2-1-jdk11-a2c68f4

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -11,7 +11,7 @@ on:
       CORE_TAG:
         type: string
         required: false
-        default: 4.13.2-1-jdk11-a73d9b7
+        default: 4.13.2-1-jdk11-a2c68f4
         description: CORE_TAG to build
       IMAGE_NAME:
         description: Name of image to publish to dockerhub, e.g. 'dwolla/my-image'


### PR DESCRIPTION
`-a2c68f4` adds the necessary git config to use `GH_TOKEN` to authenticate with GitHub.com, if it's available.

I _think_ this needs to be updated first, then we can publish a new `NVM_TAG` version, and I'll circle back to update line 9 with that as well.