### PR TITLE
plt-1919: upgrade default CORE_TAG to 3261.v9c670a_4748a_9-8-jdk11-2bbea7f

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -11,7 +11,7 @@ on:
       CORE_TAG:
         type: string
         required: false
-        default: 4.13.2-1-jdk11-a2c68f4
+        default: 3261.v9c670a_4748a_9-8-jdk11-2bbea7f
         description: CORE_TAG to build
       IMAGE_NAME:
         description: Name of image to publish to dockerhub, e.g. 'dwolla/my-image'


### PR DESCRIPTION
Updates the default CORE_TAG in the reusable build workflow.